### PR TITLE
Issue #5 - Changed 'index.html' breakpoints to fix viewport layouts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ Please see 'References.txt' for the list of sources I used in this project.
       <div class="container-fluid my-5">
         <div class="row">
             <!-- Information Section with <h2> "Welcome" subheading and <p> text. -->
-            <div class="col-sm-6 saveForLater text-center" id="about">
+            <div class="col-sm saveForLater text-center" id="about"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col-sm-6"> to <div class = "col-sm"> -->
                 <h2 class="fw-bold sectionHeading">Welcome</h2>
                 <hr class="my-4 mx-4">
                 <p class="text-secondary">
@@ -82,7 +82,7 @@ Please see 'References.txt' for the list of sources I used in this project.
                 <form class="like"></form>   
             </div>
             <!-- Image Section -->
-            <div class="col-sm-6 saveForLater text-center">
+            <div class="col-sm saveForLater text-center"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col-sm-6"> to <div class = "col-sm"> -->
                 <img 
                   src="./images_Folder/yellowCanary.jpg" 
                   alt="yellow canary" 
@@ -100,7 +100,7 @@ Please see 'References.txt' for the list of sources I used in this project.
       <div class="container my-5">
         <div class="row">
           <!-- Image Section -->
-          <div class="col-sm-6 text-center saveForLater"> 
+          <div class="col-sm mb-5 text-center saveForLater"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col-sm-6"> to <div class = "col-sm mb-5"> -->
             <img 
               src="./images_Folder/peacock.jpg" 
               alt="peacock" 
@@ -109,22 +109,22 @@ Please see 'References.txt' for the list of sources I used in this project.
               <form class="like"></form> 
           </div>
           <!-- Information Section with <h2> "Resources" subheading, <p> text and internal link icons. -->
-          <div class="col-sm-6 mt-5 text-center saveForLater">
+          <div class="col-sm mt-5 text-center saveForLater"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col-sm-6"> to <div class = "col-sm"> -->
             <h2 class="fw-bold sectionHeading " id="resources">Resources</h2>
             <hr class="my-4 mx-4">
             <p class="text-secondary">
               Click on an icon to find out more.
             </p>
             <div class="row px-0 pb-2 mb-5 my-3 mx-0">
-              <div class="col">
+              <div class="col-sm-auto"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col"> to <div class = "col-sm-auto"> -->
                 <a href="./HTML_Folder/getStarted.html"><i class="bi bi-journal-check"></i></a>
                 Get started
               </div>
-              <div class="col">
+              <div class="col-sm-auto"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col"> to <div class = "col-sm-auto"> -->
                 <a href="./HTML_Folder/gallery.html"><i class="bi bi-binoculars"></i></a>
                 Gallery
               </div>
-              <div class="col">
+              <div class="col-sm-auto"> <!-- IFS_L2T16 (Issue-5): changed <div class = "col"> to <div class = "col-sm-auto"> -->
                 <a href="./HTML_Folder/films.html"><i class="bi bi-camera-reels"></i></a>
                 Films
               </div>


### PR DESCRIPTION
As per Issue #5, the following div element's classes have been changed to fit smaller viewports without overlapping:
Line 75: div class = "col-sm-6" changed to div class = "col-sm"
Line 85: div class = "col-sm-6" changed to div class = "col-sm"
Line 103: div class = "col-sm-6" changed to div class = "col-sm mb-5"
Line 112: div class = "col-sm-6" changed to div class = "col-sm"
Line 119: div class = "col" changed to div class = "col-sm-auto"
Line 123: div class = "col" changed to div class = "col-sm-auto"
Line 127: div class = "col" changed to div class = "col-sm-auto"